### PR TITLE
fix libtorrent-rasterbar on x86_64-w64-mingw32.static; fix qbittorrent

### DIFF
--- a/plugins/apps/qbittorrent-1-fixes.patch
+++ b/plugins/apps/qbittorrent-1-fixes.patch
@@ -54,3 +54,41 @@ index 1111111..2222222 100755
  if test -r "$QT_QMAKE/qmake-qt4"; then
    eval "$as_ac_File=yes"
  else
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Mon, 30 May 2016 00:09:20 +0200
+Subject: [PATCH] disable BOOST_ASIO_SEPARATE_COMPILATION
+
+After upgrading libtorrent-rasterbar to 1.1.0, qbittorrent fails to link
+main executable with undefined symbols in boost_asio:
+
+    ./release/application.o:application.cpp:(.text.startup+0x83):
+    undefined reference to `boost::asio::detail::winsock_init_base::startup
+    (boost::asio::detail::winsock_init_base::data&, unsigned char,
+    unsigned char)'
+
+diff --git a/cmake/Modules/winconf.cmake b/cmake/Modules/winconf.cmake
+index 1111111..2222222 100644
+--- a/cmake/Modules/winconf.cmake
++++ b/cmake/Modules/winconf.cmake
+@@ -5,7 +5,6 @@
+ set(LibtorrentRasterbar_USE_STATIC_LIBS True)
+ set(LibtorrentRasterbar_CUSTOM_DEFINITIONS 
+     -DBOOST_ALL_NO_LIB -DBOOST_ASIO_HASH_MAP_BUCKETS=1021
+-    -DBOOST_ASIO_SEPARATE_COMPILATION
+     -DBOOST_EXCEPTION_DISABLE
+     -DBOOST_SYSTEM_STATIC_LINK=1
+     -DTORRENT_USE_OPENSSL
+diff --git a/winconf.pri b/winconf.pri
+index 1111111..2222222 100644
+--- a/winconf.pri
++++ b/winconf.pri
+@@ -21,7 +21,6 @@ LIBS += $$quote(-LC:/qBittorrent/openssl/lib)
+ # LIBTORRENT DEFINES
+ DEFINES += BOOST_ALL_NO_LIB
+ DEFINES += BOOST_ASIO_HASH_MAP_BUCKETS=1021
+-DEFINES += BOOST_ASIO_SEPARATE_COMPILATION
+ # After 1.55 some Windows users reported regular UI freezes.
+ # This makes ASIO use the pre-1.56 way of doing things. See issue #2003
+ DEFINES += BOOST_ASIO_DISABLE_CONNECTEX

--- a/plugins/apps/qbittorrent-1-fixes.patch
+++ b/plugins/apps/qbittorrent-1-fixes.patch
@@ -57,6 +57,34 @@ index 1111111..2222222 100755
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 29 May 2016 23:35:25 +0200
+Subject: [PATCH] link with boost_random and boost_chrono
+
+libtorrent-rasterbar 1.1.0 uses them
+
+diff --git a/winconf-mingw.pri b/winconf-mingw.pri
+index 1111111..2222222 100644
+--- a/winconf-mingw.pri
++++ b/winconf-mingw.pri
+@@ -23,11 +23,15 @@ RC_FILE = qbittorrent_mingw.rc
+ # Adapt the lib names/versions accordingly
+ CONFIG(debug, debug|release) {
+   LIBS += libtorrent-rasterbar \
++          libboost_random-mt \
++          libboost_chrono-mt \
+           libboost_system-mt \
+           libboost_filesystem-mt \
+           libboost_thread_win32-mt
+ } else {
+   LIBS += libtorrent-rasterbar \
++          libboost_random-mt \
++          libboost_chrono-mt \
+           libboost_system-mt \
+           libboost_filesystem-mt \
+           libboost_thread_win32-mt
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
 Date: Mon, 30 May 2016 00:09:20 +0200
 Subject: [PATCH] disable BOOST_ASIO_SEPARATE_COMPILATION
 

--- a/src/libtorrent-rasterbar-1-fixes.patch
+++ b/src/libtorrent-rasterbar-1-fixes.patch
@@ -1,0 +1,33 @@
+This file is part of MXE.
+See index.html for further information.
+
+Contains ad hoc patches for cross building.
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Mon, 30 May 2016 00:10:30 +0200
+Subject: [PATCH] disable BOOST_ASIO_SEPARATE_COMPILATION
+
+After upgrading libtorrent-rasterbar to 1.1.0, qbittorrent fails to link
+main executable with undefined symbols in boost_asio:
+
+    ./release/application.o:application.cpp:(.text.startup+0x83):
+    undefined reference to `boost::asio::detail::winsock_init_base::startup
+    (boost::asio::detail::winsock_init_base::data&, unsigned char,
+    unsigned char)'
+
+diff --git a/include/libtorrent/config.hpp b/include/libtorrent/config.hpp
+index 1111111..2222222 100644
+--- a/include/libtorrent/config.hpp
++++ b/include/libtorrent/config.hpp
+@@ -64,10 +64,6 @@ POSSIBILITY OF SUCH DAMAGE.
+ #error TORRENT_DEBUG_BUFFERS only works if you also disable pool allocators with TORRENT_DISABLE_POOL_ALLOCATOR
+ #endif
+ 
+-#if !defined BOOST_ASIO_SEPARATE_COMPILATION && !defined BOOST_ASIO_DYN_LINK
+-#define BOOST_ASIO_SEPARATE_COMPILATION
+-#endif
+-
+ #ifndef _MSC_VER
+ #ifndef __STDC_FORMAT_MACROS
+ #define __STDC_FORMAT_MACROS 1

--- a/src/libtorrent-rasterbar.mk
+++ b/src/libtorrent-rasterbar.mk
@@ -26,7 +26,7 @@ define $(PKG)_BUILD
         --disable-debug \
         --disable-tests \
         --disable-examples \
-        CXXFLAGS='-D_WIN32_WINNT=0x0501'
+        CXXFLAGS='-D_WIN32_WINNT=0x0501 -g -O2'
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)' -j 1 install
 endef


### PR DESCRIPTION
Build was tested on i686-w64-mingw32.static and x86_64-w64-mingw32.static.
The application was tested on i686-w64-mingw32.static with Windows XP.

@tonytheodore, can you recheck this on OSX and 64-bit Windows, please?
